### PR TITLE
Allow installation/use without flash attention dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@
 
 # Table of Contents
 
-- [FAESM: A Drop-in Efficient Pytorch Implementation of ESM2](#faesm-a-drop-in-efficient-pytorch-implementation-of-esm)
-  - [Installation](#installation)
-  - [Usage](#usage)
+- [FAESM: A Drop-in Efficient Pytorch Implementation of ESM2](#faesm-a-drop-in-efficient-pytorch-implementation-of-esm2)
+- [Table of Contents](#table-of-contents)
+- [Installation](#installation)
+- [Usage](#usage)
     - [Training \[WIP\]](#training-wip)
-  - [Benchmarking](#benchmarking)
-  - [Appreciation](#appreciation)
-  - [Citation](#citation)
+- [Benchmarking](#benchmarking)
+- [TODOs](#todos)
+- [Appreciation](#appreciation)
+- [Citation](#citation)
 
 # Installation
 
@@ -39,6 +41,12 @@ Having trouble installing flash attention but still want to use it? A workaround
 3. Install FAESM from github:
 
 ```bash
+# if you want to use flash attention
+pip install faesm[flash_attn]
+```
+
+```bash
+# if you want to forego flash attention and just use SDPA
 pip install faesm
 ```
 

--- a/faesm/esm.py
+++ b/faesm/esm.py
@@ -5,6 +5,7 @@
 flash_attn_installed = True
 try:
     from flash_attn import flash_attn_varlen_qkvpacked_func
+    from faesm.rotary import RotaryEmbedding as FAEsmRotaryEmbedding
 except ImportError:
     flash_attn_installed = False
     print(
@@ -42,7 +43,7 @@ from transformers.models.esm.modeling_esm import (
     EsmSelfOutput,
 )
 
-from faesm.rotary import RotaryEmbedding as FAEsmRotaryEmbedding
+
 from faesm.utils import unpad
 
 logger = logging.getLogger(__name__)

--- a/faesm/esm.py
+++ b/faesm/esm.py
@@ -6,6 +6,7 @@ flash_attn_installed = True
 try:
     from flash_attn import flash_attn_varlen_qkvpacked_func
     from faesm.rotary import RotaryEmbedding as FAEsmRotaryEmbedding
+    from faesm.utils import unpad
 except ImportError:
     flash_attn_installed = False
     print(
@@ -43,8 +44,6 @@ from transformers.models.esm.modeling_esm import (
     EsmSelfOutput,
 )
 
-
-from faesm.utils import unpad
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,12 @@ requirements = [
     "setuptools",
     "torch",
     "einops",
-    "flash_attn",
     "transformers",
 ]
+
+extras_require = {
+    'flash_attn': ['flash_attn'],
+}
 
 
 setup(
@@ -23,5 +26,6 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=requirements,
+    extras_require=extras_require,
     test_suite="tests",
 )


### PR DESCRIPTION
Nice repo! Thanks for sharing.

Apologies in advance if I misunderstood something, but I wanted to use `faesm` with just the SDPA upgrade and found that I was unable to install or run it without `flash-attn`.

I made a couple of small changes as a workaround:
- Change `setup.py` to make `flash-attn` an optional dependency
- Make imports from the `rotary` and `utils` modules conditional on having `flash-attn` installed